### PR TITLE
Fix optional type hint import

### DIFF
--- a/query_profiler_analysis.py
+++ b/query_profiler_analysis.py
@@ -32,6 +32,8 @@
 
 # COMMAND ----------
 
+from typing import Any, Dict, List, Optional
+
 # MAGIC %md
 # MAGIC # 🔧 Configuration & Setup Section
 # MAGIC
@@ -323,6 +325,9 @@ def extract_optimization_points_from_query(query: str, trial_type: str, attempt_
         optimization_points.append("⚡ General query structure optimization")
     
     return f"Trial {attempt_num} ({trial_type}): {'; '.join(optimization_points)}"
+ 
+# Ensure typing names are available in this cell context
+from typing import Any, Dict, List, Optional
 
 def save_optimization_points_summary(
     optimization_point: str,
@@ -655,9 +660,8 @@ print("=" * 50)
 # ⚙️ Basic environment configuration
 import json
 # pandas is not used; import removed to avoid unnecessary dependency
-from typing import Dict, List, Any, Optional
 from datetime import datetime
-
+ 
 print("✅ Basic library import completed")
 print("🚀 Please proceed to the next cell")
 


### PR DESCRIPTION
Add missing `typing` imports to resolve `NameError` for type annotations and remove a redundant import.

---
<a href="https://cursor.com/background-agent?bcId=bc-60b33101-70be-44e0-8e61-4c28096f005c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-60b33101-70be-44e0-8e61-4c28096f005c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

