### PR TITLE
Fix syntax error in cell two

### DIFF
--- a/query_profiler_analysis.py
+++ b/query_profiler_analysis.py
@@ -32,8 +32,6 @@
 
 # COMMAND ----------
 
-from typing import Any, Dict, List, Optional
-
 # MAGIC %md
 # MAGIC # 🔧 Configuration & Setup Section
 # MAGIC


### PR DESCRIPTION
Remove misplaced `from typing` import from a Markdown cell to resolve a `SyntaxError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3edff95-ee1e-4642-9fdf-84244d8aa9da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3edff95-ee1e-4642-9fdf-84244d8aa9da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

