### PR TITLE
Delete performance logs when debug is disabled

### DIFF
--- a/query_profiler_analysis.py
+++ b/query_profiler_analysis.py
@@ -16159,6 +16159,22 @@ try:
                     _deleted_count += 1
             except Exception as _e:
                 print(f"❌ Deletion failed: {_file_path} - {str(_e)}")
+        
+        # 🚮 Also remove performance judgment logs when debug is disabled
+        try:
+            import glob
+            _perf_log_files = glob.glob("output_performance_judgment_log_*.txt")
+            for _file_path in _perf_log_files:
+                try:
+                    if os.path.exists(_file_path):
+                        os.remove(_file_path)
+                        print(f"✅ Deletion completed: {_file_path}")
+                        _deleted_count += 1
+                except Exception as _e:
+                    print(f"❌ Deletion failed: {_file_path} - {str(_e)}")
+        except Exception as _e:
+            print(f"⚠️ Cleanup step for performance judgment logs encountered an error: {str(_e)}")
+        
         if _deleted_count == 0:
             print("📁 No additional intermediate text files found for deletion")
 except Exception as _e:


### PR DESCRIPTION
Delete `output_performance_judgment_log_*.txt` files during cleanup when debug mode is disabled (`DEBUG_ENABLED='N'`).

---
<a href="https://cursor.com/background-agent?bcId=bc-0bad7e4b-96cb-4cc2-a0c1-055bf05dd85e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0bad7e4b-96cb-4cc2-a0c1-055bf05dd85e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

