### PR TITLE
Register text file cleanup on debug disable

### DIFF
--- a/query_profiler_analysis.py
+++ b/query_profiler_analysis.py
@@ -80,27 +80,6 @@ EXPLAIN_ENABLED = 'Y'
 # 🐛 Debug mode setting (DEBUG_ENABLED: 'Y' = keep intermediate files, 'N' = keep final files only)
 DEBUG_ENABLED = 'Y'
 
-# Register a robust cleanup to ensure text files are removed when DEBUG is disabled
-try:
-    import atexit
-    import os as _os_for_cleanup
-
-    def _cleanup_text_files_when_debug_disabled() -> None:
-        debug_flag = str(globals().get('DEBUG_ENABLED', 'N')).upper()
-        if debug_flag != 'Y':
-            for _fname in ("optimization_points_summary.txt", "trial_logs.txt"):
-                try:
-                    if _os_for_cleanup.path.exists(_fname):
-                        _os_for_cleanup.remove(_fname)
-                except Exception:
-                    # Silent best-effort cleanup; detailed logging happens in final cleanup
-                    pass
-
-    atexit.register(_cleanup_text_files_when_debug_disabled)
-except Exception:
-    # If atexit is unavailable, rely on end-of-script cleanup defined later
-    pass
-
 # 🚀 Iterative optimization maximum attempt count settings (MAX_OPTIMIZATION_ATTEMPTS: default 2 times)
 # Number of improvement attempts when performance degradation is detected
 # - 1st attempt: Initial optimization query generation and performance verification
@@ -286,6 +265,27 @@ STRICT_VALIDATION_MODE = 'N'
 DEBUG_JSON_ENABLED = 'N'
 
 # COMMAND ----------
+
+# Register a robust cleanup to ensure text files are removed when DEBUG is disabled
+try:
+    import atexit
+    import os as _os_for_cleanup
+
+    def _cleanup_text_files_when_debug_disabled() -> None:
+        debug_flag = str(globals().get('DEBUG_ENABLED', 'N')).upper()
+        if debug_flag != 'Y':
+            for _fname in ("optimization_points_summary.txt", "trial_logs.txt"):
+                try:
+                    if _os_for_cleanup.path.exists(_fname):
+                        _os_for_cleanup.remove(_fname)
+                except Exception:
+                    # Silent best-effort cleanup; detailed logging happens in final cleanup
+                    pass
+
+    atexit.register(_cleanup_text_files_when_debug_disabled)
+except Exception:
+    # If atexit is unavailable, rely on end-of-script cleanup defined later
+    pass
 
 # === 🎯 Query Optimization Points Extraction Functions ===
 


### PR DESCRIPTION
Move cleanup registration block from Cell 4 to Cell 8 in `query_profiler_analysis.py` as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-e04e2e1a-981f-4eb2-8890-2f4b33372650">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e04e2e1a-981f-4eb2-8890-2f4b33372650">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

