### PR TITLE
Fix report formatting for liquid clustering

### DIFF
--- a/query_profiler_analysis.py
+++ b/query_profiler_analysis.py
@@ -3985,6 +3985,10 @@ def analyze_bottlenecks_with_llm(metrics: Dict[str, Any]) -> str:
             report_lines.append("")
     
     # 付記: キー選定ガイドライン（常に表示）
+    report_lines.append("## 📋 テーブル最適化推奨")
+    report_lines.append("")
+    report_lines.append("### 📘 Liquid Clustering キー選定ガイドライン")
+    report_lines.append("")
     report_lines.append(get_liquid_clustering_guidelines())
     report_lines.append("")
     
@@ -10372,7 +10376,7 @@ Please check:
     # Append Liquid Clustering guidelines as an appendix if not already included
     try:
         _guidelines_text = get_liquid_clustering_guidelines()
-        if ("キー選定ガイドライン" not in report) and ("Key Selection Guidelines" not in report):
+        if ("### 📘 Liquid Clustering キー選定ガイドライン" not in report) and ("### 📘 Liquid Clustering Key Selection Guidelines" not in report):
             if OUTPUT_LANGUAGE == 'ja':
                 report += "\n## 📋 テーブル最適化推奨\n\n### 📘 Liquid Clustering キー選定ガイドライン\n\n" + _guidelines_text + "\n"
             else:
@@ -11276,7 +11280,7 @@ def save_optimized_sql_files(original_query: str, optimized_result: str, metrics
     # ✅ 最終レポートからガイドラインが除去された場合に備え再付与
     try:
         _gl_text = get_liquid_clustering_guidelines()
-        if ("キー選定ガイドライン" not in refined_report) and ("Key Selection Guidelines" not in refined_report):
+        if ("### 📘 Liquid Clustering キー選定ガイドライン" not in refined_report) and ("### 📘 Liquid Clustering Key Selection Guidelines" not in refined_report):
             if OUTPUT_LANGUAGE == 'ja':
                 refined_report += "\n## 📋 テーブル最適化推奨\n\n### 📘 Liquid Clustering キー選定ガイドライン\n\n" + _gl_text + "\n"
             else:


### PR DESCRIPTION
Ensures Liquid Clustering guidelines are consistently formatted with the correct heading hierarchy in the final report.

The previous report generation did not consistently apply the specified "## 📋 テーブル最適化推奨 > ### 📘 Liquid Clustering キー選定ガイドライン > #### 🧭 キー選定の原則" structure. This PR directly inserts these headings before the guidelines. Additionally, the checks for re-appending these guidelines during report refinement are now more specific, looking for the full `###` heading to prevent duplicates and ensure headings are re-added if an LLM inadvertently removes them.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6b48356-86f8-44e5-9df1-aec5d86dbc9d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a6b48356-86f8-44e5-9df1-aec5d86dbc9d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

