### PR TITLE
Fix incorrect file path for saving guidelines

### DIFF
--- a/current_query_profiler_analysis.py
+++ b/current_query_profiler_analysis.py
@@ -4599,7 +4599,7 @@ if not os.path.exists(JSON_FILE_PATH):
         _guidelines_text = get_liquid_clustering_guidelines()
         from datetime import datetime as _dt
         _ts = _dt.now().strftime("%Y%m%d_%H%M%S")
-        _guidelines_path = f"/workspace/output_liquid_clustering_guidelines_{_ts}.md"
+        _guidelines_path = f"output_liquid_clustering_guidelines_{_ts}.md"
         with open(_guidelines_path, "w", encoding="utf-8") as _gf:
             _gf.write(_guidelines_text + "\n")
         print(f"💾 Guidelines saved (pre-flight): {_guidelines_path}")
@@ -5612,7 +5612,7 @@ print("\n" + guidelines_text)
 try:
     from datetime import datetime as _dt
     _ts = _dt.now().strftime("%Y%m%d_%H%M%S")
-    _guidelines_path = f"/workspace/output_liquid_clustering_guidelines_{_ts}.md"
+    _guidelines_path = f"output_liquid_clustering_guidelines_{_ts}.md"
     with open(_guidelines_path, 'w', encoding='utf-8') as _gf:
         _gf.write(guidelines_text + "\n")
     print(f"💾 Guidelines saved: {_guidelines_path}")
@@ -11602,7 +11602,7 @@ OPTIMIZE tpcds.tpcds_sf10000_delta_lc.catalog_sales FULL;
     # 💾 ガイドラインを常に個別ファイルとしても保存
     try:
         _guidelines_text = get_liquid_clustering_guidelines()
-        _guidelines_path = f"/workspace/output_liquid_clustering_guidelines_{timestamp}.md"
+        _guidelines_path = f"output_liquid_clustering_guidelines_{timestamp}.md"
         with open(_guidelines_path, 'w', encoding='utf-8') as _gf:
             _gf.write(_guidelines_text + "\n")
         print(f"💾 Guidelines saved: {_guidelines_path}")

--- a/query_profiler_analysis.py
+++ b/query_profiler_analysis.py
@@ -5104,7 +5104,7 @@ if not os.path.exists(JSON_FILE_PATH):
         _guidelines_text = get_liquid_clustering_guidelines()
         from datetime import datetime as _dt
         _ts = _dt.now().strftime("%Y%m%d_%H%M%S")
-        _guidelines_path = f"/workspace/output_liquid_clustering_guidelines_{_ts}.md"
+        _guidelines_path = f"output_liquid_clustering_guidelines_{_ts}.md"
         with open(_guidelines_path, "w", encoding="utf-8") as _gf:
             _gf.write(_guidelines_text + "\n")
         print(f"💾 Guidelines saved (pre-flight): {_guidelines_path}")
@@ -6144,7 +6144,7 @@ print("\n" + guidelines_text)
 try:
     from datetime import datetime as _dt
     _ts = _dt.now().strftime("%Y%m%d_%H%M%S")
-    _guidelines_path = f"/workspace/output_liquid_clustering_guidelines_{_ts}.md"
+    _guidelines_path = f"output_liquid_clustering_guidelines_{_ts}.md"
     with open(_guidelines_path, 'w', encoding='utf-8') as _gf:
         _gf.write(guidelines_text + "\n")
     print(f"💾 Guidelines saved: {_guidelines_path}")
@@ -12134,7 +12134,7 @@ OPTIMIZE tpcds.tpcds_sf10000_delta_lc.catalog_sales FULL;
     # 💾 ガイドラインを常に個別ファイルとしても保存
     try:
         _guidelines_text = get_liquid_clustering_guidelines()
-        _guidelines_path = f"/workspace/output_liquid_clustering_guidelines_{timestamp}.md"
+        _guidelines_path = f"output_liquid_clustering_guidelines_{timestamp}.md"
         with open(_guidelines_path, 'w', encoding='utf-8') as _gf:
             _gf.write(_guidelines_text + "\n")
         print(f"💾 Guidelines saved: {_guidelines_path}")


### PR DESCRIPTION
Remove hardcoded `/workspace/` prefix from guideline file paths to resolve "No such file or directory" errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae261eff-cff4-45ac-8a00-903ced6256e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae261eff-cff4-45ac-8a00-903ced6256e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

