### PR TITLE
Calculate repartition hint parallelism

### DIFF
--- a/REPARTITION_HINT_CONDITIONS_UPDATE.md
+++ b/REPARTITION_HINT_CONDITIONS_UPDATE.md
@@ -51,10 +51,10 @@ if node_analysis["is_shuffle_node"]:
 if "Memory efficiency improvement" in repartition_reason:
     memory_per_partition_mb = (peak_memory_bytes / num_tasks) / (1024 * 1024)
     target_partitions = int((memory_per_partition_mb / 512) * num_tasks)
-    suggested_partitions = max(target_partitions, 200, num_tasks * 2)
+    suggested_partitions = max(target_partitions, num_tasks * 2)
 else:
-    # スピル改善の場合: 従来のロジック
-    suggested_partitions = max(num_tasks * 2, 200)
+    # スピル改善の場合: メモリ効率計算ロジックに統一
+    suggested_partitions = max(target_partitions, num_tasks * 2)
 ```
 
 ## 🎯 **実際の適用例**

--- a/query_profiler_analysis.py
+++ b/query_profiler_analysis.py
@@ -1867,16 +1867,12 @@ def extract_detailed_bottleneck_analysis(extracted_metrics: Dict[str, Any]) -> D
         if should_add_repartition_hint:
             shuffle_attributes = extract_shuffle_attributes(node)
             if shuffle_attributes:
-                # パーティション数の計算ロジックを改善
-                if "Memory efficiency improvement" in repartition_reason:
-                    # メモリ効率改善の場合: 目標512MB/パーティションに基づいて計算
-                    peak_memory_bytes = node.get('key_metrics', {}).get('peakMemoryBytes', 0)
-                    memory_per_partition_mb = (peak_memory_bytes / num_tasks) / (1024 * 1024)
-                    target_partitions = int((memory_per_partition_mb / 512) * num_tasks)
-                    suggested_partitions = max(target_partitions, 200, num_tasks * 2)
-                else:
-                    # スピル改善の場合: 従来のロジック
-                    suggested_partitions = max(num_tasks * 2, 200)
+                # パーティション数の計算ロジック（メモリ効率悪化時統一）
+                # すべてのケースで目標512MB/パーティションに基づいて計算
+                peak_memory_bytes = node.get('key_metrics', {}).get('peakMemoryBytes', 0)
+                memory_per_partition_mb = (peak_memory_bytes / num_tasks) / (1024 * 1024)
+                target_partitions = int((memory_per_partition_mb / 512) * num_tasks)
+                suggested_partitions = max(target_partitions, num_tasks * 2)
                 
                 # Shuffle属性で検出されたカラムを全て使用（完全一致）
                 repartition_columns = ", ".join(shuffle_attributes)
@@ -6006,7 +6002,15 @@ if final_sorted_nodes:
                 
                 # REPARTITIONヒントの提案（スピルが検出された場合のみ）
                 if spill_detected and spill_bytes > 0 and spill_display:
-                    suggested_partitions = max(num_tasks * 2, 200)  # 最小200パーティション
+                    # メモリ効率計算ロジックに統一
+                    peak_memory_bytes = node.get('key_metrics', {}).get('peakMemoryBytes', 0)
+                    if peak_memory_bytes > 0 and num_tasks > 0:
+                        memory_per_partition_mb = (peak_memory_bytes / num_tasks) / (1024 * 1024)
+                        target_partitions = int((memory_per_partition_mb / 512) * num_tasks)
+                        suggested_partitions = max(target_partitions, num_tasks * 2)
+                    else:
+                        # フォールバック：従来ロジック
+                        suggested_partitions = max(num_tasks * 2, 100)
                     
                     # Shuffle属性で検出されたカラムを全て使用（完全一致）
                     repartition_columns = ", ".join(shuffle_attributes)
@@ -8997,7 +9001,15 @@ def generate_top10_time_consuming_processes_report(extracted_metrics: Dict[str, 
                     
                     # REPARTITIONヒントの提案（スピルが検出された場合のみ）
                     if spill_detected and spill_bytes > 0 and spill_display:
-                        suggested_partitions = max(num_tasks * 2, 200)  # 最小200パーティション
+                        # メモリ効率計算ロジックに統一
+                        peak_memory_bytes = node.get('key_metrics', {}).get('peakMemoryBytes', 0)
+                        if peak_memory_bytes > 0 and num_tasks > 0:
+                            memory_per_partition_mb = (peak_memory_bytes / num_tasks) / (1024 * 1024)
+                            target_partitions = int((memory_per_partition_mb / 512) * num_tasks)
+                            suggested_partitions = max(target_partitions, num_tasks * 2)
+                        else:
+                            # フォールバック：従来ロジック
+                            suggested_partitions = max(num_tasks * 2, 100)
                         
                         # Shuffle属性で検出されたカラムを全て使用（完全一致）
                         repartition_columns = ", ".join(shuffle_attributes)


### PR DESCRIPTION
Unify REPARTITION hint parallelization calculation to consistently use memory efficiency-based logic across all scenarios.

---
<a href="https://cursor.com/background-agent?bcId=bc-8dc817f6-0843-4385-817d-99e4e92cfbb7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8dc817f6-0843-4385-817d-99e4e92cfbb7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

