### PR TITLE
Review repartition hint value

### DIFF
--- a/current_query_profiler_analysis.py
+++ b/current_query_profiler_analysis.py
@@ -7731,6 +7731,11 @@ Shuffle効率性スコア: {efficiency_rate:.1f}%
 【🔄 REPARTITIONヒント（スピル検出時のみ）】
 {chr(10).join(repartition_hints) if repartition_hints else "スピルが検出されていないため、REPARTITIONヒントは適用対象外です"}
 
+【🚨 CRITICAL: REPARTITIONパーティション数の注意事項】
+- 上記の具体的な計算済みREPARTITIONヒントが提供されている場合は、その正確な数値を使用してください
+- 200などの固定値は使用せず、必ず分析結果で計算された具体的なパーティション数を適用してください
+- 例：REPARTITION(810, cs_bill_customer_sk) など、分析で推奨された数値を正確に使用
+
 【🚀 処理速度重視の最適化推奨事項】
 {chr(10).join(speed_optimization_recommendations) if speed_optimization_recommendations else "特別な推奨事項はありません"}
 
@@ -7893,7 +7898,7 @@ Sparkの自動JOIN戦略を使用（エラー回避のためヒントは使用�
        JOIN large_table ON small_table.key = large_table.key
    ),
    repartitioned_for_groupby AS (
-     SELECT /*+ REPARTITION(200, group_key) */
+     SELECT /*+ REPARTITION(calculated_partitions, group_key) */
        columns...
      FROM efficient_joined
    )
@@ -7939,7 +7944,7 @@ REPARTITIONヒントを付与する場合は以下の最適化ルールを守っ
 ```sql
 -- ❌ 間違い: トップレベルのSELECT句（書き込み段階のみに影響）
 CREATE TABLE optimized_table AS
-SELECT /*+ REPARTITION(200, join_key) */
+SELECT /*+ REPARTITION(calculated_partitions, join_key) */
   t1.column1, t2.column2
 FROM table1 t1
   JOIN table2 t2 ON t1.join_key = t2.join_key
@@ -7949,7 +7954,7 @@ CREATE TABLE optimized_table AS
 SELECT 
   t1.column1, t2.column2
 FROM (
-  SELECT /*+ REPARTITION(200, join_key) */
+  SELECT /*+ REPARTITION(calculated_partitions, join_key) */
     column1, join_key
   FROM table1
 ) t1
@@ -7965,7 +7970,7 @@ FROM (
 **一般的なクエリでの正しいREPARTITIONヒント配置例:**
 ```sql
 -- ❌ 間違い: トップレベルのSELECT句（最終出力段階のみに影響）
-SELECT /*+ REPARTITION(200, join_key) */
+SELECT /*+ REPARTITION(calculated_partitions, join_key) */
   t1.column1, t2.column2
 FROM table1 t1
   JOIN table2 t2 ON t1.join_key = t2.join_key
@@ -7974,7 +7979,7 @@ FROM table1 t1
 SELECT 
   t1.column1, t2.column2
 FROM (
-  SELECT /*+ REPARTITION(200, join_key) */
+  SELECT /*+ REPARTITION(calculated_partitions, join_key) */
     column1, join_key
   FROM table1
 ) t1
@@ -7984,12 +7989,12 @@ FROM (
 SELECT 
   t1.column1, t2.column2, t3.column3
 FROM (
-  SELECT /*+ REPARTITION(200, join_key) */
+  SELECT /*+ REPARTITION(calculated_partitions, join_key) */
     column1, join_key
   FROM table1
 ) t1
   JOIN (
-    SELECT /*+ REPARTITION(200, join_key) */
+    SELECT /*+ REPARTITION(calculated_partitions, join_key) */
       column2, join_key
     FROM table2
   ) t2 ON t1.join_key = t2.join_key
@@ -8040,7 +8045,7 @@ FROM (
 ✅ **REPARTITIONヒントの正しい配置:**
 ```sql
 -- REPARTITIONヒントはメインクエリのSELECT直後に配置
-SELECT /*+ REPARTITION(200, column_name) */
+SELECT /*+ REPARTITION(calculated_partitions, column_name) */
   column1, column2, ...
 FROM table1 t1
   JOIN table2 t2 ON t1.id = t2.id
@@ -8049,7 +8054,7 @@ FROM table1 t1
 ✅ **DISTINCT句との正しい組み合わせ（絶対必須）:**
 ```sql
 -- 🚨 重要: DISTINCT句は必ずヒント句の後に配置
-SELECT /*+ REPARTITION(200, column_name) */ DISTINCT
+SELECT /*+ REPARTITION(calculated_partitions, column_name) */ DISTINCT
   cs.ID, cs.column1, cs.column2, ...
 FROM table1 cs
   JOIN table2 t2 ON cs.id = t2.id
@@ -8092,9 +8097,9 @@ FROM table1 cs
 
 ```sql
 -- 🚨 重要: REPARTITIONヒントはメインクエリのSELECT文の直後に配置
--- 例: SELECT /*+ REPARTITION(200, column_name) */ column1, column2, ...
--- 🚨 DISTINCT句保持例: SELECT /*+ REPARTITION(200, column_name) */ DISTINCT cs.ID, cs.column1, ...
--- 🚨 REPARTITIONヒントの適切な配置: SELECT /*+ REPARTITION(200, join_key) */ column1, column2, ...
+-- 例: SELECT /*+ REPARTITION(calculated_partitions, column_name) */ column1, column2, ...
+-- 🚨 DISTINCT句保持例: SELECT /*+ REPARTITION(calculated_partitions, column_name) */ DISTINCT cs.ID, cs.column1, ...
+-- 🚨 REPARTITIONヒントの適切な配置: SELECT /*+ REPARTITION(calculated_partitions, join_key) */ column1, column2, ...
 -- ❌ 禁止: BROADCASTヒント（/*+ BROADCAST */、/*+ BROADCAST(table) */）は一切使用禁止
 -- ✅ 推奨: Sparkの自動JOIN戦略に委ねてヒント不使用で最適化
 [完全なSQL - すべてのカラム・CTE・テーブル名を省略なしで記述]


### PR DESCRIPTION
Replaced hardcoded `REPARTITION(200, ...)` examples and added a critical instruction to the LLM prompt to ensure calculated partition counts are used.

The LLM was incorrectly using `200` as a fixed value for `REPARTITION` hints, despite being provided with calculated values, due to the prevalence of `200` in documentation examples. This PR updates these examples and adds a strong prompt instruction to prioritize the calculated values.

---
<a href="https://cursor.com/background-agent?bcId=bc-86e749a2-8371-4a09-99b0-c81565760399">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86e749a2-8371-4a09-99b0-c81565760399">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

