### PR TITLE
Delete output files if debug is disabled

### DIFF
--- a/current_query_profiler_analysis.py
+++ b/current_query_profiler_analysis.py
@@ -16759,7 +16759,7 @@ except Exception as _e:
 print("🎉 All processing completed!")
 print("📁 Please check the generated files and utilize the analysis results.")
 
-# 🧹 Cleanup: Remove liquid_clustering_analysis_*.md in non-debug mode
+# 🧹 Cleanup: Remove liquid_clustering_analysis_*.md and output_liquid_clustering_guidelines_*.md in non-debug mode
 try:
     _debug_enabled_cleanup = str(globals().get('DEBUG_ENABLED', 'N')).upper()
     if _debug_enabled_cleanup != 'Y':
@@ -16768,6 +16768,8 @@ try:
         for _pattern in (
             "liquid_clustering_analysis_*.md",
             "/workspace/liquid_clustering_analysis_*.md",
+            "output_liquid_clustering_guidelines_*.md",
+            "/workspace/output_liquid_clustering_guidelines_*.md",
         ):
             for _md in glob.glob(_pattern):
                 try:

--- a/query_profiler_analysis.py
+++ b/query_profiler_analysis.py
@@ -17337,7 +17337,7 @@ except Exception as _e:
 print("🎉 All processing completed!")
 print("📁 Please check the generated files and utilize the analysis results.")
 
-# 🧹 Cleanup: Remove liquid_clustering_analysis_*.md in non-debug mode
+# 🧹 Cleanup: Remove liquid_clustering_analysis_*.md and output_liquid_clustering_guidelines_*.md in non-debug mode
 try:
     _debug_enabled_cleanup = str(globals().get('DEBUG_ENABLED', 'N')).upper()
     if _debug_enabled_cleanup != 'Y':
@@ -17346,6 +17346,8 @@ try:
         for _pattern in (
             "liquid_clustering_analysis_*.md",
             "/workspace/liquid_clustering_analysis_*.md",
+            "output_liquid_clustering_guidelines_*.md",
+            "/workspace/output_liquid_clustering_guidelines_*.md",
         ):
             for _md in glob.glob(_pattern):
                 try:


### PR DESCRIPTION
Delete `output_liquid_clustering_guidelines_*.md` files when `DEBUG_ENABLED` is 'N' to clean up intermediate files after processing.

---
<a href="https://cursor.com/background-agent?bcId=bc-41f851f2-ad96-4d8e-a38a-c75d1e480f05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-41f851f2-ad96-4d8e-a38a-c75d1e480f05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

