### PR TITLE
Delete enhanced shuffle analysis files when debug is off

### DIFF
--- a/current_query_profiler_analysis.py
+++ b/current_query_profiler_analysis.py
@@ -16759,7 +16759,7 @@ except Exception as _e:
 print("🎉 All processing completed!")
 print("📁 Please check the generated files and utilize the analysis results.")
 
-# 🧹 Cleanup: Remove liquid_clustering_analysis_*.md and output_liquid_clustering_guidelines_*.md in non-debug mode
+# 🧹 Cleanup: Remove liquid_clustering_analysis_*.md, output_liquid_clustering_guidelines_*.md, and output_enhanced_shuffle_analysis_*.md in non-debug mode
 try:
     _debug_enabled_cleanup = str(globals().get('DEBUG_ENABLED', 'N')).upper()
     if _debug_enabled_cleanup != 'Y':
@@ -16770,12 +16770,14 @@ try:
             "/workspace/liquid_clustering_analysis_*.md",
             "output_liquid_clustering_guidelines_*.md",
             "/workspace/output_liquid_clustering_guidelines_*.md",
+            "output_enhanced_shuffle_analysis_*.md",
+            "/workspace/output_enhanced_shuffle_analysis_*.md",
         ):
             for _md in glob.glob(_pattern):
                 try:
                     os.remove(_md)
-                    print(f"🧹 Deleted liquid clustering markdown (non-debug mode): {_md}")
+                    print(f"🧹 Deleted markdown file (non-debug mode): {_md}")
                 except Exception as _e:
                     print(f"⚠️ Failed to delete {_md}: {_e}")
 except Exception as _e:
-    print(f"⚠️ Cleanup step for liquid clustering markdown encountered an error: {str(_e)}")
+    print(f"⚠️ Cleanup step for markdown files encountered an error: {str(_e)}")

--- a/query_profiler_analysis.py
+++ b/query_profiler_analysis.py
@@ -17337,7 +17337,7 @@ except Exception as _e:
 print("🎉 All processing completed!")
 print("📁 Please check the generated files and utilize the analysis results.")
 
-# 🧹 Cleanup: Remove liquid_clustering_analysis_*.md and output_liquid_clustering_guidelines_*.md in non-debug mode
+# 🧹 Cleanup: Remove liquid_clustering_analysis_*.md, output_liquid_clustering_guidelines_*.md, and output_enhanced_shuffle_analysis_*.md in non-debug mode
 try:
     _debug_enabled_cleanup = str(globals().get('DEBUG_ENABLED', 'N')).upper()
     if _debug_enabled_cleanup != 'Y':
@@ -17348,12 +17348,14 @@ try:
             "/workspace/liquid_clustering_analysis_*.md",
             "output_liquid_clustering_guidelines_*.md",
             "/workspace/output_liquid_clustering_guidelines_*.md",
+            "output_enhanced_shuffle_analysis_*.md",
+            "/workspace/output_enhanced_shuffle_analysis_*.md",
         ):
             for _md in glob.glob(_pattern):
                 try:
                     os.remove(_md)
-                    print(f"🧹 Deleted liquid clustering markdown (non-debug mode): {_md}")
+                    print(f"🧹 Deleted markdown file (non-debug mode): {_md}")
                 except Exception as _e:
                     print(f"⚠️ Failed to delete {_md}: {_e}")
 except Exception as _e:
-    print(f"⚠️ Cleanup step for liquid clustering markdown encountered an error: {str(_e)}")
+    print(f"⚠️ Cleanup step for markdown files encountered an error: {str(_e)}")


### PR DESCRIPTION
Add cleanup for `output_enhanced_shuffle_analysis_*.md` files when `DEBUG_ENABLED` is 'N'.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8a64f46-ae5a-458b-ab50-6056d68d569f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c8a64f46-ae5a-458b-ab50-6056d68d569f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

