### PR TITLE
Process cell31 data

### DIFF
--- a/query_profiler_analysis.py
+++ b/query_profiler_analysis.py
@@ -2702,7 +2702,7 @@ def calculate_bottleneck_indicators(metrics: Dict[str, Any]) -> Dict[str, Any]:
         indicators['total_shuffle_io_bytes'] = total_shuffle_io_bytes
         
         # 全体I/Oに対するシャッフルI/Oの比率
-        total_io_bytes = overall_metrics.get('read_bytes', 0) + overall_metrics.get('read_remote_bytes', 0)
+        total_io_bytes = overall.get('read_bytes', 0) + overall.get('read_remote_bytes', 0)
         if total_io_bytes > 0:
             indicators['shuffle_io_ratio'] = total_shuffle_io_bytes / total_io_bytes
         else:


### PR DESCRIPTION
Fix `NameError` by using `overall` instead of `overall_metrics` for I/O calculations.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a87b531-c28d-4c40-9e38-19baac1f4c0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3a87b531-c28d-4c40-9e38-19baac1f4c0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

