### PR TITLE
Analyze sql profiler metrics for errors

### DIFF
--- a/query_profiler_analysis.py
+++ b/query_profiler_analysis.py
@@ -2484,6 +2484,8 @@ def calculate_bottleneck_indicators(metrics: Dict[str, Any]) -> Dict[str, Any]:
     indicators = {}
     
     overall = metrics.get('overall_metrics', {})
+    # Ensure compatibility - alias for any code that might use overall_metrics directly
+    overall_metrics = overall
     total_time = overall.get('total_time_ms', 0)
     execution_time = overall.get('execution_time_ms', 0)
     compilation_time = overall.get('compilation_time_ms', 0)


### PR DESCRIPTION
Add `overall_metrics` alias to `overall` in `calculate_bottleneck_indicators` to resolve `NameError` due to inconsistent variable usage.

The `calculate_bottleneck_indicators` function correctly defined `overall = metrics.get('overall_metrics', {})`. However, a `NameError` indicated that `overall_metrics` was being directly referenced without being defined in the function's scope, likely due to a legacy reference or copy-paste error. This alias ensures backward compatibility and prevents the error.

---
<a href="https://cursor.com/background-agent?bcId=bc-73256a73-ef59-4793-b820-b8617daaecd4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-73256a73-ef59-4793-b820-b8617daaecd4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

