### PR TITLE
Fix unbound glob error in optimization

### DIFF
--- a/query_profiler_analysis.py
+++ b/query_profiler_analysis.py
@@ -4338,11 +4338,12 @@ def analyze_bottlenecks_with_llm(metrics: Dict[str, Any]) -> str:
     photon_explanation = ""
     cost_statistics = ""
     
+    # Import required modules at the beginning to avoid UnboundLocalError
+    import glob
+    import os
+    
     explain_enabled = globals().get('EXPLAIN_ENABLED', 'N')
     if explain_enabled.upper() == 'Y':
-        import glob
-        import os
-        
         print("🔍 For bottleneck analysis: Searching EXPLAIN + EXPLAIN COST result files...")
         
         # 最新のEXPLAIN結果ファイルを検索
@@ -4392,6 +4393,9 @@ def analyze_bottlenecks_with_llm(metrics: Dict[str, Any]) -> str:
                 print(f"⚠️ Failed to load cached EXPLAIN COST results: {str(e)}")
                 # フォールバック: 従来のファイル検索
                 cached_cost_result = None
+        
+        # Initialize cost_files variable to avoid UnboundLocalError
+        cost_files = []
         
         # フォールバック: キャッシュが利用できない場合は従来のファイル検索
         if not cached_cost_result:
@@ -8116,11 +8120,12 @@ def generate_optimized_query_with_llm(original_query: str, analysis_result: str,
     photon_explanation = ""
     cost_statistics = ""
     
+    # Import required modules at the beginning to avoid UnboundLocalError
+    import glob
+    import os
+    
     explain_enabled = globals().get('EXPLAIN_ENABLED', 'N')
     if explain_enabled.upper() == 'Y':
-        import glob
-        import os
-        
         print("🔍 Searching for EXPLAIN + EXPLAIN COST result files...")
         
         # 1. Search for latest EXPLAIN result files (supporting new filename patterns)


### PR DESCRIPTION
Fix `UnboundLocalError` and enable LLM-based query optimization when EXPLAIN is disabled.

The `glob` and `os` modules were conditionally imported only when `EXPLAIN_ENABLED` was 'Y'. This caused an `UnboundLocalError` when `EXPLAIN_ENABLED` was 'N', leading to the LLM optimization process failing and an emergency fallback saving the original query as the "optimized" result. Moving the imports ensures correct execution of bottleneck analysis and LLM optimization.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ac03341-78b4-48d9-a6a7-445ae2f368a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2ac03341-78b4-48d9-a6a7-445ae2f368a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

