### PR TITLE
Fix unbound adoption sentence in report generation

### DIFF
--- a/query_profiler_analysis.py
+++ b/query_profiler_analysis.py
@@ -11472,6 +11472,7 @@ The following topics are analyzed for process evaluation:
                 # 📄 Add original query file name information
                 if latest_sql_filename:
                     selection_reason_en += f"\n- 📄 Reference file: {latest_sql_filename} (optimization trial result)"
+                adoption_sentence_en = ""  # Add missing assignment
             elif explain_enabled.upper() == 'N' and best_attempt_number >= 1:
                 final_selection_en = f"Optimized Query (attempt {best_attempt_number})"
                 selection_reason_en = "🔍 EXPLAIN disabled optimization query selection reason clarified: Adopting bottleneck analysis-based optimized query"


### PR DESCRIPTION
Initialize `adoption_sentence_en` in the `best_attempt_number == 0` branch to resolve `UnboundLocalError`.

The `adoption_sentence_en` variable was referenced without being assigned when `best_attempt_number` was 0, causing an `UnboundLocalError`. This change ensures it is always initialized.

---
<a href="https://cursor.com/background-agent?bcId=bc-214d8b52-9dbe-4e02-8c92-263fe091d806">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-214d8b52-9dbe-4e02-8c92-263fe091d806">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

