### PR TITLE
Disable debug mode

### DIFF
--- a/query_profiler_analysis.py
+++ b/query_profiler_analysis.py
@@ -77,7 +77,7 @@ CATALOG = 'tpcds'
 DATABASE = 'tpcds_sf1000_delta_lc'
 
 # 🐛 Debug mode setting (DEBUG_ENABLED: 'Y' = keep intermediate files, 'N' = keep final files only)
-DEBUG_ENABLED = 'Y'
+DEBUG_ENABLED = 'N'
 
 # 🚀 Iterative optimization maximum attempt count settings (MAX_OPTIMIZATION_ATTEMPTS: default 3 times)
 # 🔄 New design: Each attempt is clearly evaluated


### PR DESCRIPTION
Disable debug mode by setting `DEBUG_ENABLED` to 'N' to keep only final files instead of intermediate files.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8088a44-7437-499f-87b7-0e9879087d04">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e8088a44-7437-499f-87b7-0e9879087d04">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

