### PR TITLE
Fix missing List import

### DIFF
--- a/query_profiler_analysis.py
+++ b/query_profiler_analysis.py
@@ -303,6 +303,7 @@ print(f"⚙️ Shuffle analysis enabled: {SHUFFLE_ANALYSIS_CONFIG['shuffle_analy
 try:
     import atexit
     import os as _os_for_cleanup
+    from typing import List, Dict, Any, Optional
 
     def _cleanup_text_files_when_debug_disabled() -> None:
         debug_flag = str(globals().get('DEBUG_ENABLED', 'N')).upper()


### PR DESCRIPTION
Add missing `typing` imports to resolve `NameError` for type annotations in a Databricks notebook cell.

This file is an exported Databricks notebook. The `NameError` occurred because functions using type hints were defined in a cell that lacked the necessary `typing` module imports, even though these imports existed in a different, later cell.

---
<a href="https://cursor.com/background-agent?bcId=bc-339dfb1b-71e3-4a73-a32b-6c5fc024d74f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-339dfb1b-71e3-4a73-a32b-6c5fc024d74f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

